### PR TITLE
Update for ResourceLoader module changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 dist/
 node_modules/
-/.mw_credentials
+/.mw_credentials*

--- a/acdc.js
+++ b/acdc.js
@@ -11,15 +11,14 @@
 			'oojs-ui.styles.icons-editing-list',
 			'wikibase.mediainfo.statements',
 			'wikibase.utilities.ClaimGuidGenerator',
-			'wikibase.datamodel.Statement',
-			'wikibase.datamodel.Claim',
-			'wikibase.datamodel.PropertyNoValueSnak',
-			'wikibase.serialization.StatementListDeserializer',
-			'wikibase.serialization.StatementSerializer',
-			'wikibase.serialization.StatementDeserializer',
+			'wikibase.datamodel',
+			'wikibase.serialization',
 			'mediawiki.api',
 			'mediawiki.util',
 		] ),
+		ClaimGuidGenerator = wikibase.utilities.ClaimGuidGenerator,
+		{ Statement, Claim, PropertyNoValueSnak } = require( 'wikibase.datamodel' ),
+		{ StatementListDeserializer, StatementSerializer, StatementDeserializer } = require( 'wikibase.serialization' ),
 		{ StatementWidget, AddPropertyWidget } = require( 'wikibase.mediainfo.statements' );
 
 	/**
@@ -120,11 +119,11 @@
 	}
 
 	function sanityCheckStatementEquals() {
-		const snak = new wikibase.datamodel.PropertyNoValueSnak( 'P1' ),
-			claim1 = new wikibase.datamodel.Claim( snak, null, 'guid 1' ),
-			statement1 = new wikibase.datamodel.Statement( claim1 ),
-			claim2 = new wikibase.datamodel.Claim( snak, null, 'guid 2' ),
-			statement2 = new wikibase.datamodel.Statement( claim2 );
+		const snak = new PropertyNoValueSnak( 'P1' ),
+			claim1 = new Claim( snak, null, 'guid 1' ),
+			statement1 = new Statement( claim1 ),
+			claim2 = new Claim( snak, null, 'guid 2' ),
+			statement2 = new Statement( claim2 );
 		if ( !statement1.equals( statement2 ) ) {
 			// if different GUIDs break Statement.equals, we can’t detect duplicate statements
 			failSanityCheck( 'Statement.equals' );
@@ -649,11 +648,11 @@
 					const entityData = await entityIdsToData( Object.values( entityIds ), [ 'info', 'claims' ] );
 					this.statementsProgressBarWidget.finishedLoadingEntityData();
 
-					const statementListDeserializer = new wikibase.serialization.StatementListDeserializer(),
-						statementSerializer = new wikibase.serialization.StatementSerializer(),
-						statementDeserializer = new wikibase.serialization.StatementDeserializer();
+					const statementListDeserializer = new StatementListDeserializer(),
+						statementSerializer = new StatementSerializer(),
+						statementDeserializer = new StatementDeserializer();
 					for ( const [ title, entityId ] of Object.entries( entityIds ) ) {
-						const guidGenerator = new wikibase.utilities.ClaimGuidGenerator( entityId );
+						const guidGenerator = new ClaimGuidGenerator( entityId );
 
 						for ( const statementWidget of this.statementWidgets ) {
 							const previousStatements = statementListDeserializer.deserialize(
@@ -674,8 +673,8 @@
 
 												updatedStatement.getClaim().getQualifiers().merge( newStatement.getClaim().getQualifiers() );
 
-												if ( newStatement.getRank() !== wikibase.datamodel.Statement.RANK.NORMAL &&
-													updatedStatement.getRank() === wikibase.datamodel.Statement.RANK.NORMAL ) {
+												if ( newStatement.getRank() !== Statement.RANK.NORMAL &&
+													updatedStatement.getRank() === Statement.RANK.NORMAL ) {
 													updatedStatement.setRank( newStatement.getRank() );
 												}
 
@@ -690,8 +689,8 @@
 										}
 									}
 									// no existing statement matched, add new
-									return [ new wikibase.datamodel.Statement(
-										new wikibase.datamodel.Claim( newStatement.getClaim().getMainSnak(), newStatement.getClaim().getQualifiers(), guidGenerator.newGuid() ),
+									return [ new Statement(
+										new Claim( newStatement.getClaim().getMainSnak(), newStatement.getClaim().getQualifiers(), guidGenerator.newGuid() ),
 										newStatement.getReferences(),
 										newStatement.getRank()
 									) ];

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -99,6 +99,7 @@ module.exports.config = {
 	// If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
 	// gets prepended directly.
 	baseUrl: 'https://commons.wikimedia.beta.wmflabs.org',
+	// baseUrl: 'https://test-commons.wikimedia.org',
 	//
 	// Default timeout for all waitFor* commands.
 	waitforTimeout: 10000,


### PR DESCRIPTION
The `wikibase.datamodel.*` and `wikibase.serialization.*` modules were merged into one (each), so we should import them differently. (Currently, the old modules are still available in production, but already removed in beta, where this was noticed by the browser tests.)

To make testing in both environments simpler, I added a commented-out alternative base URL to `wdio.conf.js` and split `.mw_credentials` into `.mw_credentials_beta` and `.mw_credentials_test`, to be used like this:

```sh
(. .mw_credentials_beta && make check)
(. .mw_credentials_test && make check)
```

Depending on which line in `wdio.conf.js` is currently active.

`(wikibase.util.)ClaimGuidGenerator` is also prepared for new-style imports (as in, assigned to a top-level variable instead of directly accessing it in `wikibase.util` where it’s used), though that module
is still not exported that way yet.

---

@Ladsgroup is this the right way to use the new modules? (Well, aside from the fact that they probably shouldn’t be used at all, since they’re not stable interfaces.)