### PR TITLE
Prepare for other datatype support in WikibaseMediaInfo

### DIFF
--- a/acdc.js
+++ b/acdc.js
@@ -533,12 +533,13 @@
 		const addPropertyWidget = new AddPropertyWidget( {
 			$overlay: this.$overlay,
 		} );
-		addPropertyWidget.on( 'choose', ( { id } ) => {
+		addPropertyWidget.on( 'choose', ( _widget, { id, datatype } ) => {
 			const statementWidget = new StatementWidget( {
 				entityId: '', // this widget is reused for multiple entities, we inject the entity IDs on publish
 				propertyId: id,
 				isDefaultProperty: false,
-				properties: { [ id ]: 'wikibase-entityid' }, // pretend all properties use entity IDs, for now
+				propertyType: datatype,
+				properties: { [ id ]: 'wikibase-entityid' }, // backwards compatibility until d69067b8da23dd8f0e98abc5694f38b59cb05e0f is deployed everywhere
 				$overlay: this.$overlay,
 				tags: this.tags,
 			} );


### PR DESCRIPTION
WikibaseMediaInfo will soon gain support for additional datatypes, which means we need to pass the correct datatype of the selected property into the `StatementWidget`. Fortunately, we already receive this as part of the arguments to the `AddPropertyWidget`’s “choose” event – I just hadn’t seen it before because I was looking in the first argument, which seems to be some widget (I’m not sure which one, actually), while the data is really the second argument.

Fixes #3 – thanks a lot to @egardner for the notification!