### PR TITLE
Iterate over object using `for` ... `in`

### DIFF
--- a/acdc.js
+++ b/acdc.js
@@ -179,7 +179,7 @@
 		} );
 		// TODO change back to Object.fromEntries() once MediaWiki supports ES2019
 		const datatypes = {};
-		for ( const [ propertyId, { datatype } ] of response.entities ) {
+		for ( const [ propertyId, { datatype } ] in response.entities ) {
 			datatypes[ propertyId ] = datatype;
 		}
 		return datatypes;


### PR DESCRIPTION
`for` ... `of` iteration is reserved for arrays in JS, while `response.entities` is an object. Attempting to iterate over its entries this way results in an error in console.